### PR TITLE
Add shared FRB init utilities; bump to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.0
+
+- **Breaking**: Bumped minimum Dart SDK to `>=3.6.0 <4.0.0`
+- Added `frb_init.dart` module with Flutter Rust Bridge initialization utilities:
+  - `frbDynamicLibraryName()` -- builds platform-correct FRB library filenames (handles macOS no-prefix convention)
+  - `frbFullLibraryPath()` -- resolves full path with macOS prefix-strip workaround
+  - `initializeFrbLibrary()` -- high-level init function replacing ~95 lines of duplicated init logic across FRB packages
+- Added `flutter_rust_bridge` as a dependency (for `ExternalLibrary` type)
+
 ## 0.9.0
 
 - Added `flutter_example` application for testing dynamic library resolution in compiled applications

--- a/lib/dynamic_library.dart
+++ b/lib/dynamic_library.dart
@@ -2,3 +2,4 @@ library dynamic_library;
 
 export 'src/wrapper_class.dart';
 export 'src/loader.dart';
+export 'src/frb_init.dart';

--- a/lib/src/frb_init.dart
+++ b/lib/src/frb_init.dart
@@ -1,0 +1,174 @@
+import 'dart:ffi' show Abi;
+import 'dart:io' show Directory, File, Platform;
+import 'dart:typed_data' show ByteData;
+
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_io.dart' show ExternalLibrary;
+
+import 'loader.dart' show fullLibraryPath;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tier A: Helpers (building blocks)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build the platform-correct dynamic library filename for an FRB package.
+///
+/// Unlike the generic [fullLibraryName] in `loader.dart`, this function
+/// accounts for the FRB convention where macOS libraries are NOT prefixed
+/// with `lib` (e.g. `runtime_native_audio.dylib`), while Linux libraries
+/// ARE prefixed (e.g. `libruntime_native_audio.so`).
+///
+/// Returns an empty string if the current platform/architecture is not
+/// recognized -- callers should handle this as an error.
+String frbDynamicLibraryName(String packageName) {
+  if (Abi.current() == Abi.macosArm64) return '$packageName.dylib';
+  if (Abi.current() == Abi.macosX64) return '$packageName.dylib';
+  if (Abi.current() == Abi.windowsX64) return '$packageName.dll';
+  if (Platform.isLinux) return 'lib$packageName.so';
+  return '';
+}
+
+/// Resolve the full path for an FRB dynamic library.
+///
+/// Calls [fullLibraryPath] and then applies the macOS prefix-strip workaround:
+/// `fullLibraryPath` prepends `lib` on all Unix-like systems, but on macOS our
+/// FRB libraries are NOT prefixed. On Linux they ARE prefixed, so no stripping
+/// is needed.
+String frbFullLibraryPath(String packageName) {
+  String path = fullLibraryPath(packageName);
+  final String dylibName = frbDynamicLibraryName(packageName);
+
+  if (Platform.isMacOS) {
+    path = path.replaceFirst('lib$dylibName', dylibName);
+  }
+
+  return path;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tier B: High-level init function
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Initialize a Flutter Rust Bridge library by package name.
+///
+/// This is the single entry point that replaces the duplicated init logic
+/// across all FRB packages. It handles:
+///
+/// - Parameter validation
+/// - Local resolution (for `dart run` development)
+/// - Byte-based resolution (for Flutter asset bundles)
+/// - Explicit path resolution (for direct file paths)
+/// - System resolution via [fullLibraryPath] (for production app bundles)
+/// - The macOS `lib` prefix workaround
+///
+/// Parameters:
+/// - [packageName]: The package name, e.g. `'runtime_native_audio'`
+/// - [rustLibInit]: The package's `RustLib.init` function reference
+/// - [libPath]: Explicit path to the dynamic library file
+/// - [libBytes]: Raw bytes of the dynamic library (e.g. from an asset bundle)
+/// - [libBytesCacheDir]: Directory to cache [libBytes] on disk
+/// - [assumeLocalResolution]: When `true` (default), resolves the library
+///   relative to `Directory.current` (for `dart run`). When `false`, uses
+///   system resolution or an explicit path/bytes.
+///
+/// Example usage in a package's `init.dart`:
+/// ```dart
+/// import 'package:dynamic_library/dynamic_library.dart';
+/// import 'rust/generated/frb_generated.dart' show RustLib;
+///
+/// const String PACKAGE_NAME = 'runtime_native_audio';
+/// String get DYNAMIC_LIBRARY_NAME => frbDynamicLibraryName(PACKAGE_NAME);
+///
+/// bool _isInitialized = false;
+///
+/// Future<void> initialize({
+///   String? libPath,
+///   ByteData? libBytes,
+///   Directory? libBytesCacheDir,
+///   bool assumeLocalResolution = true,
+/// }) async {
+///   if (_isInitialized) return;
+///   await initializeFrbLibrary(
+///     packageName: PACKAGE_NAME,
+///     rustLibInit: RustLib.init,
+///     libPath: libPath,
+///     libBytes: libBytes,
+///     libBytesCacheDir: libBytesCacheDir,
+///     assumeLocalResolution: assumeLocalResolution,
+///   );
+///   _isInitialized = true;
+/// }
+/// ```
+Future<void> initializeFrbLibrary({
+  required String packageName,
+  required Future<void> Function({required ExternalLibrary externalLibrary}) rustLibInit,
+  String? libPath,
+  ByteData? libBytes,
+  Directory? libBytesCacheDir,
+  bool assumeLocalResolution = true,
+}) async {
+  // ── Parameter validation ──
+  if (libPath is String && assumeLocalResolution) {
+    throw ArgumentError(
+      'When passing in a libPath, assumeLocalResolution must explicitly be set to false.',
+    );
+  }
+  if (libBytes != null && assumeLocalResolution) {
+    throw ArgumentError(
+      'When passing in libBytes, assumeLocalResolution must explicitly be set to false.',
+    );
+  }
+  if (libBytes != null && libBytesCacheDir is! Directory) {
+    throw ArgumentError(
+      'When passing in libBytes, libBytesCacheDir must be set and '
+      'assumeLocalResolution must explicitly be set to false.',
+    );
+  }
+
+  // ── Resolve the library file ──
+  File? file;
+  final String fileName = frbDynamicLibraryName(packageName);
+  final String slash = Platform.pathSeparator;
+
+  if (assumeLocalResolution) {
+    // Local resolution: look for the dylib in the standard FRB build output path
+    // relative to the current working directory (for `dart run` development).
+    final List<String> rootSegments = [
+      Directory.current.path,
+      'lib',
+      'src',
+      'ffi',
+      'io',
+      'rust',
+      'generated',
+      'io',
+      Abi.current().toString(),
+    ];
+    file = File([...rootSegments, fileName].join(slash));
+    file.existsSync() ||
+        (throw ArgumentError(
+          'The file at ${file.absolute.path} does not exist. '
+          'Ensure you have run utils/build.dart before trying to use the library from source.',
+        ));
+  } else if (libBytes is ByteData) {
+    // Byte-based resolution: write the library bytes to a cache directory and load from there.
+    if (libBytesCacheDir is! Directory) {
+      throw ArgumentError('When passing in libBytes, libBytesCacheDir must be set.');
+    }
+    file = File([libBytesCacheDir.path, fileName].join(slash));
+    if (!await file.exists()) await file.create(recursive: false);
+    await file.writeAsBytes(libBytes.buffer.asUint8List(), flush: true);
+  } else if (libPath is String) {
+    // Explicit path resolution: load from the given path directly.
+    file = File(libPath);
+    file.existsSync() || (throw ArgumentError('The file at $libPath does not exist.'));
+  } else {
+    // System resolution: use fullLibraryPath with the macOS prefix-strip workaround.
+    // This resolves to the app bundle's Frameworks directory on macOS or system library
+    // paths on Linux. We don't check for file existence here because ExternalLibrary.open
+    // will check multiple locations; allow it to throw if the library cannot be resolved.
+    file = File(frbFullLibraryPath(packageName));
+  }
+
+  // ── Load the library via FRB ──
+  await rustLibInit(externalLibrary: ExternalLibrary.open(file.path)).catchError((e) => throw e);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,17 @@
 name: dynamic_library
-description: Dart library for improving the process of loading dynamic libraries (with OS-specific load checks)
-version: 0.9.0
+description: Dart library for improving the process of loading dynamic libraries (with OS-specific load checks) and initializing Flutter Rust Bridge packages.
+version: 1.0.0
 homepage: https://github.com/open-runtime/dynamic_library
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.6.0 <4.0.0'
+
+resolution: workspace
 
 dependencies:
+  flutter_rust_bridge: ^2.9.0
   path: ^1.8.0
 
 dev_dependencies:
   runtime_lints: ^0.3.0
-  test: ^1.16.0
+  test: ^1.25.0


### PR DESCRIPTION
## Integrate OpenCode Engine, Native Audio, and Enhance Workspace Tooling

**Branched from:** [main](https://github.com/open-runtime/dynamic_library/tree/main)
**Branch:** [`feat/opencode-and-audio-polishing`](https://github.com/open-runtime/dynamic_library/tree/feat/opencode-and-audio-polishing)
**PR into:** [main](https://github.com/open-runtime/dynamic_library/tree/main)

## Summary

This PR upgrades the `dynamic_library` package to version `1.0.0`. It introduces shared Flutter Rust Bridge (FRB) initialization utilities in `frb_init.dart` to reduce boilerplate and improve consistency across FRB-based projects.

## Changes

- Bump package version to `1.0.0` in `pubspec.yaml`.
- Introduce `lib/src/frb_init.dart` containing `frbDynamicLibraryName`, `frbFullLibraryPath`, and `initializeFrbLibrary` for streamlined FRB initialization.
- Update the minimum Dart SDK requirement to `>=3.6.0 <4.0.0`.
- Add `flutter_rust_bridge` as a direct dependency for `ExternalLibrary` type usage in the new FRB utilities.

### Related PRs
- https://github.com/pieces-app/unified_monorepo/pull/2
- https://github.com/pieces-app/platform_factory/pull/48
- https://github.com/pieces-app/os_server/pull/2589
- https://github.com/pieces-app/isomorphic_server/pull/728
- https://github.com/pieces-app/ml_facade/pull/1329
- https://github.com/pieces-app/mcp_dart/pull/2
- https://github.com/open-runtime/native_audio/pull/55
- https://github.com/open-runtime/vector_search/pull/102
- https://github.com/open-runtime/runtime_embedded_opencode_engine/pull/4
- https://github.com/open-runtime/dart_acp/pull/2
- https://github.com/pieces-app/pieces_copilot_module/pull/405
- https://github.com/pieces-app/pieces_os_tray_webview/pull/144
- https://github.com/pieces-app/pieces_platform_client_sdk/pull/279
- https://github.com/open-runtime/code_highlighter/pull/12
- https://github.com/open-runtime/generated_runtime/pull/430

---
*This PR is part of a cross-repo change. All related PRs are listed above.*