### PR TITLE
chore(deps): bump SDK constraint to >=3.9.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 homepage: https://github.com/open-runtime/dynamic_library
 
 environment:
-  sdk: '>=3.6.0 <4.0.0'
+  sdk: '>=3.9.0 <4.0.0'
 
 dependencies:
   flutter_rust_bridge: ^2.9.0


### PR DESCRIPTION
Bumps SDK constraint from >=3.6.0 to >=3.9.0 to support tag_pattern in downstream consumers.