### PR TITLE
Add loadDynamicLibraryRaw for non-standard library filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.1
 
+- Added `loadDynamicLibraryRaw()` for loading libraries with non-standard filenames (e.g., versioned Linux shared objects like `libonnxruntime.so.1.23.2`)
 - Updated dependencies: unified workspace dependencies and bumped `flutter_lints` to `^6.0.0`
 - Bumped minimum Dart SDK to `>=3.9.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.1
+
+- Updated dependencies: unified workspace dependencies and bumped `flutter_lints` to `^6.0.0`
+- Bumped minimum Dart SDK to `>=3.9.0`
+
 ## 1.0.0
 
 - **Breaking**: Bumped minimum Dart SDK to `>=3.6.0 <4.0.0`

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:runtime_lints/recommended.yaml
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
   exclude:

--- a/lib/src/loader.dart
+++ b/lib/src/loader.dart
@@ -29,28 +29,49 @@ String fullLibraryName(String name) => libraryPrefix() + name + systemLibExtensi
 /// Whether this is being called by dart vs a compiled application
 bool isDart() => p.basenameWithoutExtension(Platform.resolvedExecutable) == 'dart';
 
-///
-String fullLibraryPath(String libraryName, {String? searchPath}) {
+/// Resolve a library file to a full path, validating searchPath if provided.
+String _resolveLibraryPath(String fileName, {String? searchPath}) {
   late String libraryPath;
 
-  // Get the platform specific file name
-  String libraryFile = fullLibraryName(libraryName);
-
-  // Build the dynamic library path from a search path or just a file name
   if (searchPath != null && searchPath.isNotEmpty) {
-    // Early Exit if the desired search directory doesn't exist
     Directory directory = Directory(searchPath);
     if (!directory.existsSync()) {
       throw LoadDynamicLibraryException('Search Path directory does not exist\n\tDirectory: ${directory.path}\n');
     }
-    libraryPath = p.join(searchPath, libraryFile);
+    libraryPath = p.join(searchPath, fileName);
   } else {
-    libraryPath = libraryFile;
+    libraryPath = fileName;
   }
 
-  // Use absolute paths on dart runtimes (instead of flutter applications)
   libraryPath = isDart() ? p.absolute(libraryPath) : libraryPath;
   return libraryPath;
+}
+
+///
+String fullLibraryPath(String libraryName, {String? searchPath}) {
+  return _resolveLibraryPath(fullLibraryName(libraryName), searchPath: searchPath);
+}
+
+/// Try to open a dynamic library, throwing verbose diagnostics on failure.
+DynamicLibrary _openWithDiagnostics({required String libraryPath, required String displayName, String? searchPath}) {
+  try {
+    return DynamicLibrary.open(libraryPath);
+  } catch (e) {
+    if (!File(libraryPath).existsSync()) {
+      throw LoadDynamicLibraryException('$displayName cannot be found at the following location\n'
+          '\tSearch Path: $searchPath\n'
+          '\tDesired Path: $libraryPath\n'
+          '\tCurrent Directory: ${p.current}\n'
+          '\tResolved Full Path: ${p.absolute(libraryPath)}\n');
+    }
+
+    ProcessResult dependencyCheckResult = callOSDependencyCheck(libraryPath);
+
+    throw LoadDynamicLibraryException('$e\n\n'
+        'Dependency Check:\n'
+        '\tstderr: ${dependencyCheckResult.stderr}\n'
+        '\tstdout: ${dependencyCheckResult.stdout}\n');
+  }
 }
 
 /// Load the dynamic library and throw more verbose exceptions to improve debugging
@@ -64,65 +85,16 @@ String fullLibraryPath(String libraryName, {String? searchPath}) {
 /// We recommend using [searchPath] instead for Dart applications, servers, micro-services,
 /// where you have more control over the library locations
 DynamicLibrary loadDynamicLibrary({required String libraryName, String? searchPath}) {
-  // Get the full library path
   String libraryPath = fullLibraryPath(libraryName, searchPath: searchPath);
-
-  try {
-    return DynamicLibrary.open(libraryPath);
-  } catch (e) {
-    // Try to check to see if the file just doesn't exist at this location
-    if (!File(libraryPath).existsSync()) {
-      throw LoadDynamicLibraryException('$libraryName cannot be found at the following location\n'
-          '\tSearch Path: $searchPath\n'
-          '\tDesired Path: $libraryPath\n'
-          '\tCurrent Directory: ${p.current}\n'
-          '\tResolved Full Path: ${p.absolute(libraryPath)}\n');
-    }
-
-    ProcessResult dependencyCheckResult = callOSDependencyCheck(libraryPath);
-
-    throw LoadDynamicLibraryException('$e\n\n'
-        'Dependency Check:\n'
-        '\tstderr: ${dependencyCheckResult.stderr}\n'
-        '\tstdout: ${dependencyCheckResult.stdout}\n');
-  }
+  return _openWithDiagnostics(libraryPath: libraryPath, displayName: libraryName, searchPath: searchPath);
 }
 
 /// Loads a dynamic library using an explicit filename, bypassing platform
 /// naming conventions. Use this for libraries with non-standard naming
 /// (e.g., versioned Linux shared objects like 'libonnxruntime.so.1.23.2').
 DynamicLibrary loadDynamicLibraryRaw({required String fileName, String? searchPath}) {
-  late String libraryPath;
-
-  if (searchPath != null && searchPath.isNotEmpty) {
-    Directory directory = Directory(searchPath);
-    if (!directory.existsSync()) {
-      throw LoadDynamicLibraryException(
-          'Search Path directory does not exist\n\tDirectory: ${directory.path}\n');
-    }
-    libraryPath = p.join(searchPath, fileName);
-  } else {
-    libraryPath = fileName;
-  }
-
-  libraryPath = isDart() ? p.absolute(libraryPath) : libraryPath;
-
-  try {
-    return DynamicLibrary.open(libraryPath);
-  } catch (e) {
-    if (!File(libraryPath).existsSync()) {
-      throw LoadDynamicLibraryException('$fileName cannot be found at the following location\n'
-          '\tSearch Path: $searchPath\n'
-          '\tDesired Path: $libraryPath\n'
-          '\tCurrent Directory: ${p.current}\n'
-          '\tResolved Full Path: ${p.absolute(libraryPath)}\n');
-    }
-    ProcessResult dependencyCheckResult = callOSDependencyCheck(libraryPath);
-    throw LoadDynamicLibraryException('$e\n\n'
-        'Dependency Check:\n'
-        '\tstderr: ${dependencyCheckResult.stderr}\n'
-        '\tstdout: ${dependencyCheckResult.stdout}\n');
-  }
+  String libraryPath = _resolveLibraryPath(fileName, searchPath: searchPath);
+  return _openWithDiagnostics(libraryPath: libraryPath, displayName: fileName, searchPath: searchPath);
 }
 
 /// Call OS-specific CLI tools for resolving Dynamic Library Dependencies

--- a/lib/src/loader.dart
+++ b/lib/src/loader.dart
@@ -88,6 +88,43 @@ DynamicLibrary loadDynamicLibrary({required String libraryName, String? searchPa
   }
 }
 
+/// Loads a dynamic library using an explicit filename, bypassing platform
+/// naming conventions. Use this for libraries with non-standard naming
+/// (e.g., versioned Linux shared objects like 'libonnxruntime.so.1.23.2').
+DynamicLibrary loadDynamicLibraryRaw({required String fileName, String? searchPath}) {
+  late String libraryPath;
+
+  if (searchPath != null && searchPath.isNotEmpty) {
+    Directory directory = Directory(searchPath);
+    if (!directory.existsSync()) {
+      throw LoadDynamicLibraryException(
+          'Search Path directory does not exist\n\tDirectory: ${directory.path}\n');
+    }
+    libraryPath = p.join(searchPath, fileName);
+  } else {
+    libraryPath = fileName;
+  }
+
+  libraryPath = isDart() ? p.absolute(libraryPath) : libraryPath;
+
+  try {
+    return DynamicLibrary.open(libraryPath);
+  } catch (e) {
+    if (!File(libraryPath).existsSync()) {
+      throw LoadDynamicLibraryException('$fileName cannot be found at the following location\n'
+          '\tSearch Path: $searchPath\n'
+          '\tDesired Path: $libraryPath\n'
+          '\tCurrent Directory: ${p.current}\n'
+          '\tResolved Full Path: ${p.absolute(libraryPath)}\n');
+    }
+    ProcessResult dependencyCheckResult = callOSDependencyCheck(libraryPath);
+    throw LoadDynamicLibraryException('$e\n\n'
+        'Dependency Check:\n'
+        '\tstderr: ${dependencyCheckResult.stderr}\n'
+        '\tstdout: ${dependencyCheckResult.stdout}\n');
+  }
+}
+
 /// Call OS-specific CLI tools for resolving Dynamic Library Dependencies
 ///
 /// - Windows: `dumpbin /DEPENDENTS [LIBRARY_PATH]`

--- a/test/dynamic_library_test.dart
+++ b/test/dynamic_library_test.dart
@@ -18,7 +18,7 @@ void main() {
     });
   });
 
-  group('exceptions', () {
+  group('loadDynamicLibrary exceptions', () {
     test('fails to find directory', () {
       expect(() => loadDynamicLibrary(libraryName: 'doesntexist', searchPath: 'path/to/nowhere'),
           throwsA(isA<LoadDynamicLibraryException>()));
@@ -26,6 +26,17 @@ void main() {
 
     test('fails to find file', () {
       expect(() => loadDynamicLibrary(libraryName: 'doesntexist'), throwsA(isA<LoadDynamicLibraryException>()));
+    });
+  });
+
+  group('loadDynamicLibraryRaw exceptions', () {
+    test('fails to find directory', () {
+      expect(() => loadDynamicLibraryRaw(fileName: 'doesntexist.so', searchPath: 'path/to/nowhere'),
+          throwsA(isA<LoadDynamicLibraryException>()));
+    });
+
+    test('fails to find file', () {
+      expect(() => loadDynamicLibraryRaw(fileName: 'doesntexist.so'), throwsA(isA<LoadDynamicLibraryException>()));
     });
   });
 }


### PR DESCRIPTION
## Summary
- Adds `loadDynamicLibraryRaw` function that loads a dynamic library using an explicit filename, bypassing platform naming conventions
- Useful for libraries with non-standard naming (e.g., versioned Linux shared objects like `libonnxruntime.so.1.23.2`)

## Test plan
- [ ] Verify `loadDynamicLibraryRaw` loads a library with a non-standard filename
- [ ] Verify error handling for missing search path directory
- [ ] Verify error handling for missing library file
- [ ] Verify existing `loadDynamicLibrary` behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)