### PR TITLE
chore: remove runtime_ci_tooling dev_dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,15 +6,14 @@ homepage: https://github.com/open-runtime/dynamic_library
 environment:
   sdk: '>=3.9.0 <4.0.0'
 
+
 dependencies:
   flutter_rust_bridge: ^2.11.1
   path: ^1.8.0
 
 dev_dependencies:
-  runtime_ci_tooling:
-    git:
-      url: git@github.com:open-runtime/runtime_ci_tooling.git
-      tag_pattern: "v{{version}}"
-    version: ^0.23.0
+  # runtime_ci_tooling — use global activation (do not add as a dev_dependency). Example:
+  #   dart pub global activate --source git https://github.com/open-runtime/runtime_ci_tooling.git --git-ref vX.Y.Z
+  #   dart pub global run runtime_ci_tooling:manage_cicd --help
   flutter_lints: ^6.0.0
   test: ^1.25.0


### PR DESCRIPTION
runtime_ci_tooling is globally activated in CI — not a dev_dependency. Removes workspace resolution conflict.

Made with [Cursor](https://cursor.com)