### PR TITLE
chore(ci): disable autodoc until tooling fixes land

### DIFF
--- a/.runtime_ci/config.json
+++ b/.runtime_ci/config.json
@@ -18,7 +18,7 @@
       "managed_analyze": true,
       "managed_test": true,
       "build_runner": false,
-      "autodoc": true,
+      "autodoc": false,
       "web_test": false
     },
     "secrets": {


### PR DESCRIPTION
## Summary

Flips `ci.features.autodoc` to `false` in `.runtime_ci/config.json` so the `auto-autodoc` and `docs-freshness` jobs short-circuit on main. This unblocks the v1.1.5 release pipeline, which is currently gated on a green CI run that can't go green until the two underlying tooling bugs below are fixed.

## Why main CI is red

Two issues in `runtime_ci_tooling` v0.23.10 surfaced back-to-back:

1. **`autodoc` hash function uses absolute file paths** (`autodoc_command.dart:986` — `_computeModuleHash` calls `p.normalize(p.join(repoRoot, relPath))` and digests `entity.path`). Hashes stored by a local run (e.g. under `/home/user/.../dynamic_library/lib/...`) don't match hashes computed on CI (`/home/runner/work/dynamic_library/dynamic_library/lib/...`), so PR #13's stored hash immediately went stale the moment it merged to main.
2. **`npm install -g @google/gemini-cli@latest`** currently resolves to 0.38.x, which fails with `Invalid policy rule: mcpName is required if specified (cannot be empty)` on load. That prevents `auto-autodoc` from self-healing a stale hash via Gemini regeneration.

Tracked in #14. Re-enable autodoc (flip the flag back) once a new `runtime_ci_tooling` tag lands with (a) repo-relative paths in the hash and (b) a pinned gemini-cli version (0.34.0 is known-good; avoid `@latest`).

## Verification

- [x] Local `dart pub global run runtime_ci_tooling:manage_cicd autodoc --dry-run` reports docs are fresh (against local paths) — irrelevant once the check is gated behind the feature flag.
- [x] CI passes on this branch.
- [x] Merge, confirm main CI goes green, confirm release pipeline runs and cuts v1.1.5.