### PR TITLE
chore(ci): make release-pipeline autodoc step best-effort

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -498,6 +498,10 @@ jobs:
           restore-keys: ${{ runner.os }}-go-mcp-
 
       - name: Generate module documentation
+        # Best-effort: if gemini-cli or Gemini itself errors (quota,
+        # policy schema drift in @latest, etc.), fall back to stub
+        # artifacts so the release pipeline keeps moving. Tracked in #14.
+        continue-on-error: true
         env:
           GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY_OPEN_RUNTIME }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The release pipeline's `autodoc` job (`release.yaml` line ~498) calls `gemini autodoc`, but `npm install -g @google/gemini-cli@latest` currently resolves to 0.38.x which crashes at startup with `Invalid policy rule: mcpName is required if specified (cannot be empty)`. That fails the `Generate module documentation` step, short-circuits the existing fallback logic below it, and blocks `create-release` — so v1.1.5 never ships.

Adds `continue-on-error: true` to the `Generate module documentation` step so the subsequent `Create fallback autodoc artifacts if missing` step can create stub artifacts and let the pipeline proceed (which is the clear intent of that fallback — the author already anticipated Gemini being unavailable).

## Why not also pin gemini-cli here?

The workflow is generated by `runtime_ci_tooling` (`# Generated by runtime_ci_tooling v0.23.10` at the top). Hand-editing the version pin would drift on the next regeneration. Tracked in #14 — the proper fix lives in the tooling templates and will land on the next `runtime_ci_tooling` bump. This PR is narrowly scoped to unblock v1.1.5.

## Verification

- [x] Release pipeline for commit b137444 failed exactly at this step: https://github.com/open-runtime/dynamic_library/actions/runs/24789118521/job/72541700636
- [ ] CI on this branch passes.
- [ ] Merge, release pipeline re-fires via `workflow_run`, autodoc step shows ⚠️ continue-on-error, fallback step creates stub, `create-release` runs, v1.1.5 tag cut.

Follow-up still tracked in #14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow resilience by allowing documentation generation to fail gracefully without blocking the overall release process, ensuring more reliable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->