### PR TITLE
fix(deps): pin flutter_rust_bridge to exactly 2.11.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 
 dependencies:
-  flutter_rust_bridge: ^2.11.1
+  flutter_rust_bridge: 2.11.1
   path: ^1.8.0
 
 dev_dependencies:


### PR DESCRIPTION
## Summary

`dynamic_library` was the only Flutter Rust Bridge consumer in the Pieces workspace still using a caret constraint (`^2.11.1`) instead of an exact pin. That allows a standalone resolve to float to `flutter_rust_bridge` 2.12.0.

That drift is not cosmetic. FRB enforces a codegen/runtime version match: bindings produced by a 2.12.0 codegen are stamped `codegenVersion => '2.12.0'` and fail against a 2.11.1 runtime. This is the same class of breakage that `open-runtime/vector_search` hard-pinned against in [`5c819554f`](https://github.com/open-runtime/vector_search/commit/5c819554f) ("hard-pin flutter_rust_bridge to 2.11.1"), which reverted an attempted 2.12.0 upgrade for exactly this reason.

Inside the Pieces pub workspace the exact pins in every other package forced this caret down to 2.11.1, which is why it went unnoticed. It only surfaces when `dynamic_library` resolves on its own — for example in this repo's own CI.

## Change

One line in `pubspec.yaml`:

```diff
-  flutter_rust_bridge: ^2.11.1
+  flutter_rust_bridge: 2.11.1
```

This matches the convention already used by all 20 other FRB consumers in the workspace (`backend/native_*`, `backend/vector_search`, `frontend/code_highlighter`, `frontend/flutter_mermaid`, `backend/ml_facade`, `backend/isomorphic_server`), and mirrors the `flutter_rust_bridge = "=2.11.1"` exact pins on the Rust side.

## Test plan

- [ ] CI green on this repo (standalone resolve now locks to 2.11.1 rather than floating to 2.12.0)
- [ ] `dart pub get` in a standalone checkout resolves `flutter_rust_bridge` to 2.11.1
- [x] Verified in the Pieces unified workspace: `flutter pub get` resolves cleanly and `pubspec.lock` reports `flutter_rust_bridge version: "2.11.1"`

## Notes

No CHANGELOG entry included — this repo's CHANGELOG is maintained by the release bot at tag time, not by feature PRs.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Locked the Flutter Rust Bridge dependency to version 2.11.1 for more consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->